### PR TITLE
Encapsulate optional container attributes in one object

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Get started:
 
 * `testutils` can be [installed using `go get` command](#installation)
 
+Features:
+
+* [Utility functions to work with Docker objects](#docker-package),
+* [Collection of preconfigured Docker container objects](#presets-package)
 
 `docker` package
 ----------------
@@ -21,16 +25,16 @@ Essentially, it is a collection of functions wrapping `github.com/docker/docker`
 `docker` package exposes functions for performing essential operations with Docker objects:
 
 * `PullImage(name)` - pulls a Docker image identified by `name`,
-* `CreateContainer(image, name, env, ports)` - pulls a Docker `image` and creates a new Docker `name` Docker container with `env` list of environment variables created inside the container and with exposed list of `ports`. Function returns the created container `id`,
-* `StartContainer(id)` - starts `id` Docker container,
-* `CreateStartContainer(image, name, env, ports)` - combines `CreateContainer` and `StartContainer` functions,
+* `CreateContainer(image, options)` - pulls a Docker `image` and creates a new Docker container. Optional container attributes values can be specified in `options` argument. Optional attributes list can be found below. Function returns the created container `id`,
+* `StartContainer(id)` - starts Docker container identified by given `id`,
+* `CreateStartContainer(image, options)` - combines `CreateContainer` and `StartContainer` functions,
 * `StopContainer(id)` - stops `id` Docker container,
 * `RemoveContainer(id)` - removes `id` Docker container,
 * `StopRemoveContainer(id)` - combines `StopContainer` and `RemoveContainer` functions.
 
 All functions take context.Context parameter and return error.
 
-Example:
+Example, without optional attributes:
 
 ```go
 package somepackage
@@ -45,11 +49,49 @@ import (
 
 func Test_SomeFunction(t *testing.T) {
     ctx := context.Background()
-	options := docker.ContainerOptions{
+    containerID, err := docker.CreateStartContainer(ctx, "image/name", nil)
+    require.NoError(t, err)
+    defer func() { require.NoError(t, docker.StopRemoveContainer(ctx, containerID)) }()
+
+    // Your test here
+}
+```
+
+In the example above, a few lines of code allow to:
+
+* pull an `image/name` Docker image,
+* create and start a new Docker container,
+* stop and remove the container at the end of the test.
+
+Optional attributes list:
+
+* `Name` - container name,
+* `EnvironmentVariables` - a list of environment variables to be created inside the container. Format is `name=value`,
+* `ExposedPorts` - a list of exposed ports. Format is `container_port:host_port`,
+* `Healthcheck` - a command to check whether the service inside container has started. Healthcheck commands are automatically prefixed with `CMD-SHELL`,
+* `StartTimeout` - service inside the container start timeout in seconds. The default value is `60`.
+
+Example, with optional attributes:
+
+```go
+package somepackage
+
+import (
+    "context"
+    "testing"
+
+    "github.com/stretchr/testify/require"
+    "github.com/ygrebnov/testutils/docker"
+)
+
+func Test_SomeFunction(t *testing.T) {
+    ctx := context.Background()
+	options := docker.Options{
+		Name: "test-container",
 		EnvironmentVariables: []string{"MYVAR=my-var-value"}, 
 		ExposedPorts: []string{"8080:80"},
 	}
-    containerID, err := docker.CreateStartContainer(ctx, "image/name", "test-container", options)
+    containerID, err := docker.CreateStartContainer(ctx, "image/name", &options)
     require.NoError(t, err)
     defer func() { require.NoError(t, docker.StopRemoveContainer(ctx, containerID)) }()
 
@@ -69,22 +111,24 @@ In the example above, a few lines of code allow to:
 
 `docker` package also exposes a `Container` object which holds container data and synchronizes it with the corresponding Docker container on the host.
 
-`Container` object is constructed using a builder. `Container` required attributes, `name` and `image`, values are set via the main constructor function, `NewContainerBuilder(name, image)`. Optional attributes, `env` and `ports` values can be set via additional constructor functions, `SetEnv(env []string)` and `ExposePorts(ports []string)`. The constructor functions can be chained. The last constructor function in the chain must be `Build()`, which aggregates all the attributes values set during the building process and creates the final `Container` object. Given that this package main objective is to provide the most simplified manner of working with Docker objects, the described above design approach has been chosen intentionally. An example of constructing a new `Container` object is provided below.
+`Container` object can be created using two constructors. 
+
+The first constructor, `NewContainer` takes only one parameter `image` (image name) which is the only one `Container` object attribute required on creation. 
+
+The second constructor, `NewContainerWithOptions` in addition to `image`, takes one more `options` parameter. It allows to specify `Container` object optional attributes values (the list can be found above). Optional attributes values can be specified only on new `Container` object creation. Examples of constructing new `Container` objects are provided below.
 
 `Container` object exposed methods:
 
-* `Create` - using the object attributes, pulls a Docker image, creates a new Docker container and environment variables inside the container,
-* `Start` - fetches the corresponding Docker container data and saves it as object attributes values, starts the container and waits until it starts,
+* `Create` - using the object attributes, pulls a Docker image, creates a new Docker container with all the specified attributes,
+* `Start` - starts the container and waits until it starts. If `Options.Healthcheck` has been specified, also waits until the service inside the container starts,
 * `CreateStart` - performs all the `Create` actions and starts the created container,
-* `Stop` - fetches the corresponding Docker container data and saves it as object attributes values, stops the container,
-* `Remove` - fetches the corresponding Docker container data and saves it as object attributes values, removes the container if it exists,
-* `StopRemove` - fetches the corresponding Docker container data and saves it as object attributes values, stops and removes the container if it exists.
+* `Stop` - stops the container,
+* `Remove` - removes the container if it exists,
+* `StopRemove` - stops and removes the container if it exists.
 
 All methods take context.Context parameter and return error.
 
-The main difference between using the `docker` package functions and `Container` object is that the latter allows to interact with Docker containers which may have been created before the code execution.
-
-For example, if some test requires that a new container with a specific name should be created, it can be implemented as:
+An example of using basic `NewContainer` constructor:
 
 ```go
 package somepackage
@@ -99,11 +143,35 @@ import (
 
 func Test_SomeFunction(t *testing.T) {
 	ctx := context.Background()
-	testContainer := docker.NewContainerBuilder("test-container", "image/name").
-		SetEnv([]string{"MYVAR=my-var-value"}).
-		ExposePorts([]string{"8080:80"}).
-		Healthcheck("is_service_running").
-		Build()
+	testContainer := docker.NewContainer("image/name")
+	require.NoError(t, testContainer.CreateStart(ctx)) // using "image/name" image, creates and starts a new Docker container on host
+	defer func() { require.NoError(t, testContainer.StopRemove(ctx)) }() // Docker container at the end of the test
+
+	// Your test here
+}
+```
+
+The main difference between using the `docker` package functions and `Container` object is that the latter allows to interact with Docker containers which may have been created before the code execution. For example, if some test requires that a new container with a specific name should be created, it can be implemented as:
+
+```go
+package somepackage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ygrebnov/testutils/docker"
+)
+
+func Test_SomeFunction(t *testing.T) {
+	ctx := context.Background()
+	options := docker.Options{
+		Name: "test-container",
+		EnvironmentVariables: []string{"MYVAR=my-var-value"},
+		ExposedPorts: []string{"8080:80"},
+	}
+	testContainer := docker.NewContainerWithOptions("image/name", options)
 	require.NoError(t, testContainer.StopRemove(ctx))  // stops and removes "test-container" Docker container if it exists on host
 	require.NoError(t, testContainer.CreateStart(ctx)) // creates and starts a new "test-container" Docker container on host
 	defer func() { require.NoError(t, testContainer.StopRemove(ctx)) }() // stops and removes "test-container" Docker container at the end of the test
@@ -112,6 +180,65 @@ func Test_SomeFunction(t *testing.T) {
 }
 ```
 
+
+`presets` package
+----------------
+
+`presets` package contains a collection of preset `github.com/ygrebnov/testutils/docker.Container` objects. The main idea here is to provide ready-to-use objects with most commonly used configuration already applied. For example, while creating a PostgreSQL container, we may set values of `POSTGRES_PASSWORD`, `POSTGRES_USER`, `PGPORT` environment variables, set a healthcheck based on `pg_isready` command, and expose `5432` port. `presets` package provides a preset `github.com/ygrebnov/testutils/docker.Container` object with such configuration.
+
+Each preset allows to create a new preconfigured `github.com/ygrebnov/testutils/docker.Container` object and a new preconfigured object with customizable optional attributes. For example, for the case when we want to expose port `5433` instead of port `5432` in a PostgreSQL container.
+
+List of `presets`:
+
+* PostgreSQL - preconfigured `github.com/ygrebnov/testutils/docker.Container` object can be obtained using `NewPostgresqlContainer()` function, or the same object, but customizable - using `NewCustomizedPostgresqlContainer(options docker.Options)` function.
+
+Basic example of using presets in tests:
+
+```go
+package somepackage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ygrebnov/testutils/presets"
+)
+
+func Test_SomeFunction(t *testing.T) {
+	ctx := context.Background()
+	testContainer := presets.NewPostgresqlContainer()
+	require.NoError(t, testContainer.CreateStart(ctx)) // creates and starts a new PostgreSQL Docker container on host
+	defer func() { require.NoError(t, testContainer.StopRemove(ctx)) }() // stops and removes PostgreSQL Docker container at the end of the test
+
+	// Your test here
+}
+```
+
+An example of using presets with customized attributes values:
+
+```go
+package somepackage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ygrebnov/testutils/docker"
+	"github.com/ygrebnov/testutils/presets"
+)
+
+func Test_SomeFunction(t *testing.T) {
+	ctx := context.Background()
+	options := docker.Options{ExposedPorts: []string{"5432:5433"}} // container port 5432 is bound to the host 5433 port, other configuration remains unchanged
+	testContainer := presets.NewCustomizedPostgresqlContainer(options)
+	require.NoError(t, testContainer.CreateStart(ctx)) // creates and starts a new PostgreSQL Docker container on host
+	defer func() { require.NoError(t, testContainer.StopRemove(ctx)) }() // stops and removes PostgreSQL Docker container at the end of the test
+
+	// Your test here
+}
+```
 
 Installation
 ------------

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.2
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.2
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -25,6 +26,5 @@ require (
 	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.1.12 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.4.0 // indirect
 )

--- a/presets/postgresql.go
+++ b/presets/postgresql.go
@@ -4,26 +4,13 @@ import "github.com/ygrebnov/testutils/docker"
 
 var postgresqlPreset = newPreset("values/postgresql.yml")
 
-// NewPostgresqlContainerBuilder returns a [github.com/ygrebnov/testutils/docker.ContainerBuilder] object with
-// the minimum required environmental variables created and the default 5432 port exported.
-//
-// List of created environment variables with assigned values:
-//
-// - POSTGRES_USER=postgres,
-//
-// - POSTGRES_PASSWORD=postgresqlPresetPassword,
-//
-// - PGPORT=5432.
-//
-// Before building a [github.com/ygrebnov/testutils/docker.Container] from an object returned by
-// [NewPostgresqlContainerBuilder], the latter can be modified by calling
-// [github.com/ygrebnov/testutils/docker.ContainerBuilder] SetEnv() and/or ExposePorts() methods.
-func NewPostgresqlContainerBuilder() docker.ContainerBuilder {
-	return postgresqlPreset.asContainerBuilder()
+// NewCustomizedPostgresqlContainer returns a preset [github.com/ygrebnov/testutils/docker.Container] object with
+// customized options values.
+func NewCustomizedPostgresqlContainer(options docker.Options) docker.Container {
+	return postgresqlPreset.asCustomizedContainer(options)
 }
 
-// NewPostgresqlContainer returns a built [github.com/ygrebnov/testutils/docker.Container] pre-configured like
-// the object returned by [NewPostgresqlContainerBuilder].
+// NewPostgresqlContainer returns a preset [github.com/ygrebnov/testutils/docker.Container] object.
 func NewPostgresqlContainer() docker.Container {
 	return postgresqlPreset.asContainer()
 }

--- a/presets/postgresql_test.go
+++ b/presets/postgresql_test.go
@@ -9,19 +9,14 @@ import (
 )
 
 func Test_PostgresqlPreset(t *testing.T) {
-	expectedContainerBuilder := docker.NewContainerBuilder("postgresqlPresetContainer", "postgres").
-		SetEnv([]string{"POSTGRES_USER=postgres", "POSTGRES_PASSWORD=postgresqlPresetPassword", "PGPORT=5432"}).
-		ExposePorts([]string{"5432:5432"}).
-		Healthcheck("pg_isready")
-	expectedContainer := expectedContainerBuilder.Build()
+	expectedContainer := docker.NewContainerWithOptions(
+		"postgres",
+		docker.Options{
+			Name:                 "postgresqlPresetContainer",
+			Healthcheck:          "pg_isready",
+			EnvironmentVariables: []string{"POSTGRES_USER=postgres", "POSTGRES_PASSWORD=postgresqlPresetPassword", "PGPORT=5432"},
+			ExposedPorts:         []string{"5432:5432"},
+		})
 
-	require.Equal(t, expectedContainerBuilder, NewPostgresqlContainerBuilder())
 	require.Equal(t, expectedContainer, NewPostgresqlContainer())
-}
-
-func Test_PostgresqlPresetContainerBuilderUniqueness(t *testing.T) {
-	p1 := NewPostgresqlContainerBuilder()
-	p2 := NewPostgresqlContainerBuilder()
-	p1.ExposePorts([]string{"5435:5435"})
-	require.NotEqual(t, p1, p2)
 }

--- a/presets/preset.go
+++ b/presets/preset.go
@@ -14,16 +14,19 @@ import (
 	"github.com/ygrebnov/testutils/docker"
 )
 
+// preset represents a type capable of producing preset and customizable [docker.Container] objects.
 type preset interface {
-	asContainerBuilder() docker.ContainerBuilder
 	asContainer() docker.Container
+	asCustomizedContainer(options docker.Options) docker.Container
 }
 
+// defaultPreset is a default implementation of `preset` interface. defaultPreset holds container and image data.
 type defaultPreset struct {
 	Container presetContainer `yaml:"container"`
 	Image     presetImage     `yaml:"image"`
 }
 
+// presetContainer holds preset container data.
 type presetContainer struct {
 	Name        string               `yaml:"name"`
 	Env         []presetContainerEnv `yaml:"env,omitempty"`
@@ -31,15 +34,18 @@ type presetContainer struct {
 	Healthcheck string               `yaml:"healthcheck"`
 }
 
+// presetContainerEnv holds preset container environment variables data.
 type presetContainerEnv struct {
 	Name  string `yaml:"name"`
 	Value any    `yaml:"value"`
 }
 
+// presetImage holds preset container image data.
 type presetImage struct {
 	Name string `yaml:"name"`
 }
 
+// newPreset creates a new `preset` object with attributes values from the given yaml file.
 func newPreset(valuesFile string) preset {
 	p := defaultPreset{}
 	_, currFile, _, ok := runtime.Caller(0)
@@ -57,7 +63,34 @@ func newPreset(valuesFile string) preset {
 	return &p
 }
 
-func (p *defaultPreset) asContainerBuilder() docker.ContainerBuilder {
+// asContainer returns a [docker.Container] object with preset attribute values.
+func (p *defaultPreset) asContainer() docker.Container {
+	return docker.NewContainerWithOptions(p.Image.Name, p.getPresetContainerOptions())
+}
+
+// asCustomizedContainer returns a [docker.Container] with preset attribute values overwritten by customized ones.
+func (p *defaultPreset) asCustomizedContainer(options docker.Options) docker.Container {
+	combinedOptions := p.getPresetContainerOptions()
+	if len(options.Name) > 0 {
+		combinedOptions.Name = options.Name
+	}
+	if len(options.EnvironmentVariables) > 0 {
+		combinedOptions.EnvironmentVariables = options.EnvironmentVariables
+	}
+	if len(options.ExposedPorts) > 0 {
+		combinedOptions.ExposedPorts = options.ExposedPorts
+	}
+	if len(options.Healthcheck) > 0 {
+		combinedOptions.Healthcheck = options.Healthcheck
+	}
+	if options.StartTimeout > 0 {
+		combinedOptions.StartTimeout = options.StartTimeout
+	}
+	return docker.NewContainerWithOptions(p.Image.Name, combinedOptions)
+}
+
+// getPresetContainerOptions returns a [docker.Options] object with attributes values from preset yaml file.
+func (p *defaultPreset) getPresetContainerOptions() docker.Options {
 	env := make([]string, 0, len(p.Container.Env))
 	for _, el := range p.Container.Env {
 		var stringVal string
@@ -71,13 +104,10 @@ func (p *defaultPreset) asContainerBuilder() docker.ContainerBuilder {
 		}
 		env = append(env, fmt.Sprintf("%s=%s", el.Name, stringVal))
 	}
-
-	return docker.NewContainerBuilder(p.Container.Name, p.Image.Name).
-		SetEnv(env).
-		ExposePorts(p.Container.Ports).
-		Healthcheck(p.Container.Healthcheck)
-}
-
-func (p *defaultPreset) asContainer() docker.Container {
-	return p.asContainerBuilder().Build()
+	return docker.Options{
+		Name:                 p.Container.Name,
+		Healthcheck:          p.Container.Healthcheck,
+		EnvironmentVariables: env,
+		ExposedPorts:         p.Container.Ports,
+	}
 }


### PR DESCRIPTION
* Use one Options object to specify all optional attributes values on new container object creation
* Move container name to optional attributes
* Update examples in README